### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,19 +80,19 @@ You can run inference using the provided script. The script uses `flash_attn` bu
 - Tested operating system: Linux
 
 ```shell
-export BASE_MODEL = "hunyuanvideo-community/HunyuanVideo"
-export LORA_PATH = "<PATH TO DOWNLOADED CONTROL LORA>"
-export IMAGE_1 = "<PATH TO THE FIRST FRAME>"
-export IMAGE_2 = "<PATH TO THE LAST FRAME>"
-export PROMPT = "<A BEAUTIFUL PROMPT>"
-export HEIGHT = 960
-export WIDHT = 544
-export n_FRAMES = 33
+export BASE_MODEL="hunyuanvideo-community/HunyuanVideo"
+export LORA_PATH="<PATH TO DOWNLOADED CONTROL LORA>"
+export IMAGE_1="<PATH TO THE FIRST FRAME>"
+export IMAGE_2="<PATH TO THE LAST FRAME>"
+export PROMPT="<A BEAUTIFUL PROMPT>"
+export HEIGHT=960
+export WIDTH=544
+export n_FRAMES=33
 
 python hv_control_lora_inference.py \
     --model $BASE_MODEL \
     --lora $LORA_PATH \
-    --frame1 $IMAGE_1 --frame2 $IMAGE_2 --prompt $PROMPT --frames $n_FRAMES \
+    --frame1 $IMAGE_1 --frame2 $IMAGE_2 --prompt "$PROMPT" --frames $n_FRAMES \
     --height $HEIGHT --width $WIDTH \
     --steps 50 \
     --guidance 6.0 \


### PR DESCRIPTION
1.Fix spelling errors
`export WIDHT=544` ->`export WIDTH=544`

2.Fix: Correct export command syntax
```
export BASE_MODEL="hunyuanvideo-community/HunyuanVideo"
export LORA_PATH="<PATH TO DOWNLOADED CONTROL LORA>"
export IMAGE_1="<PATH TO THE FIRST FRAME>"
export IMAGE_2="<PATH TO THE LAST FRAME>"
export PROMPT="<A BEAUTIFUL PROMPT>"
export HEIGHT=960
export WIDTH=544
export n_FRAMES=33
```
The syntax of the `export` command requires that there must be no spaces between variable names and values，otherwise an error will be reported. example
```
root@autodl-container-dd024aa9fd-92594e03:~# export BASE_MODEL = "hunyuanvideo-community/HunyuanVideo"
bash: export: `=': not a valid identifier
bash: export: `hunyuanvideo-community/HunyuanVideo': not a valid identifier
```

2.Fix: Handle multi-word prompt variable correctly
Strings containing spaces require quotation marks
for example:
```
export PROMPT="showing the changes from young to old and the passage of time"
python3 hv_control_lora_inference.py --prompt $PROMPT
```
catch the error: unrecognized arguments: the changes from young to old and the passage of time
